### PR TITLE
Ensure each CFlow can be bound to VM scope on IOS

### DIFF
--- a/revolver/src/androidMain/kotlin/com/umain/revolver/flow/CFlow.kt
+++ b/revolver/src/androidMain/kotlin/com/umain/revolver/flow/CFlow.kt
@@ -1,7 +1,9 @@
 package com.umain.revolver.flow
 
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.Flow
 
 actual class CFlow<out T : Any> actual constructor(
     private val flow: Flow<T>,
+    private val coroutineScope: CoroutineScope,
 ) : Flow<T> by flow

--- a/revolver/src/androidMain/kotlin/com/umain/revolver/flow/CSharedFlow.kt
+++ b/revolver/src/androidMain/kotlin/com/umain/revolver/flow/CSharedFlow.kt
@@ -1,7 +1,9 @@
 package com.umain.revolver.flow
 
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.SharedFlow
 
 actual open class CSharedFlow<out T : Any> actual constructor(
     private val flow: SharedFlow<T>,
-) : SharedFlow<T> by flow
+    private val coroutineScope: CoroutineScope,
+    ) : SharedFlow<T> by flow

--- a/revolver/src/androidMain/kotlin/com/umain/revolver/flow/CStateFlow.kt
+++ b/revolver/src/androidMain/kotlin/com/umain/revolver/flow/CStateFlow.kt
@@ -1,7 +1,9 @@
 package com.umain.revolver.flow
 
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.StateFlow
 
 actual open class CStateFlow<out T : Any> actual constructor(
     private val flow: StateFlow<T>,
-) : StateFlow<T> by flow
+    private val coroutineScope: CoroutineScope,
+    ) : StateFlow<T> by flow

--- a/revolver/src/commonMain/kotlin/com/umain/revolver/RevolverViewModel.kt
+++ b/revolver/src/commonMain/kotlin/com/umain/revolver/RevolverViewModel.kt
@@ -40,12 +40,12 @@ open class RevolverViewModel<EVENT : RevolverEvent, STATE : RevolverState, EFFEC
     /**
      * StateFlow for observing state changes
      */
-    override val state = _state.cStateFlow()
+    override val state = _state.cStateFlow(viewModelScope)
 
     /**
      * SharedFlow for observing side effects. Used for one of events like "Move to the next screen"
      */
-    override val effect = _effect.cSharedFlow()
+    override val effect = _effect.cSharedFlow(viewModelScope)
 
     private val emitter: Emitter<STATE, EFFECT> = object : Emitter<STATE, EFFECT> {
         override val state: StateEmitter<STATE> = { state: STATE ->

--- a/revolver/src/commonMain/kotlin/com/umain/revolver/flow/CFlow.kt
+++ b/revolver/src/commonMain/kotlin/com/umain/revolver/flow/CFlow.kt
@@ -1,7 +1,10 @@
 package com.umain.revolver.flow
 
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.flow.Flow
 
-expect class CFlow<out T : Any>(flow: Flow<T>) : Flow<T>
+expect class CFlow<out T : Any>(flow: Flow<T>, coroutineScope: CoroutineScope) : Flow<T>
 
-fun <T : Any> Flow<T>.cFlow(): CFlow<T> = CFlow(this)
+@Suppress("OPT_IN_USAGE")
+fun <T : Any> Flow<T>.cFlow(coroutineScope:  CoroutineScope = GlobalScope): CFlow<T> = CFlow(this, coroutineScope)

--- a/revolver/src/commonMain/kotlin/com/umain/revolver/flow/CSharedFlow.kt
+++ b/revolver/src/commonMain/kotlin/com/umain/revolver/flow/CSharedFlow.kt
@@ -1,7 +1,10 @@
 package com.umain.revolver.flow
 
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.flow.SharedFlow
 
-expect open class CSharedFlow<out T : Any>(flow: SharedFlow<T>) : SharedFlow<T>
+expect open class CSharedFlow<out T : Any>(flow: SharedFlow<T>, coroutineScope: CoroutineScope) : SharedFlow<T>
 
-fun <T : Any> SharedFlow<T>.cSharedFlow(): CSharedFlow<T> = CSharedFlow(this)
+@Suppress("OPT_IN_USAGE")
+fun <T : Any> SharedFlow<T>.cSharedFlow(coroutineScope:  CoroutineScope = GlobalScope): CSharedFlow<T> = CSharedFlow(this, coroutineScope)

--- a/revolver/src/commonMain/kotlin/com/umain/revolver/flow/CStateFlow.kt
+++ b/revolver/src/commonMain/kotlin/com/umain/revolver/flow/CStateFlow.kt
@@ -1,7 +1,10 @@
 package com.umain.revolver.flow
 
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.flow.StateFlow
 
-expect open class CStateFlow<out T : Any>(flow: StateFlow<T>) : StateFlow<T>
+expect open class CStateFlow<out T : Any>(flow: StateFlow<T>, coroutineScope: CoroutineScope) : StateFlow<T>
 
-fun <T : Any> StateFlow<T>.cStateFlow(): CStateFlow<T> = CStateFlow(this)
+@Suppress("OPT_IN_USAGE")
+fun <T : Any> StateFlow<T>.cStateFlow(coroutineScope: CoroutineScope = GlobalScope): CStateFlow<T> = CStateFlow(this,coroutineScope)

--- a/revolver/src/iosMain/kotlin/com/umain/revolver/flow/CFlow.kt
+++ b/revolver/src/iosMain/kotlin/com/umain/revolver/flow/CFlow.kt
@@ -3,7 +3,6 @@ package com.umain.revolver.flow
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.collect
@@ -12,6 +11,7 @@ import kotlinx.coroutines.launch
 
 actual open class CFlow<out T : Any> actual constructor(
     private val flow: Flow<T>,
+    private val coroutineScope: CoroutineScope,
 ) : Flow<T> by flow {
 
     private fun watch(
@@ -28,9 +28,8 @@ actual open class CFlow<out T : Any> actual constructor(
     }
 
     fun watch(onNext: (T) -> Unit): DisposableHandle {
-        @Suppress("OPT_IN_USAGE")
         return watch(
-            coroutineScope = GlobalScope,
+            coroutineScope = coroutineScope,
             dispatcher = Dispatchers.Main,
             onNext = onNext,
         )

--- a/revolver/src/iosMain/kotlin/com/umain/revolver/flow/CSharedFlow.kt
+++ b/revolver/src/iosMain/kotlin/com/umain/revolver/flow/CSharedFlow.kt
@@ -1,11 +1,13 @@
 package com.umain.revolver.flow
 
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.FlowCollector
 import kotlinx.coroutines.flow.SharedFlow
 
 actual open class CSharedFlow<out T : Any> actual constructor(
     private val flow: SharedFlow<T>,
-) : CFlow<T>(flow), SharedFlow<T> {
+    private val coroutineScope: CoroutineScope,
+    ) : CFlow<T>(flow,coroutineScope), SharedFlow<T> {
     override val replayCache: List<T> get() = flow.replayCache
 
     override suspend fun collect(collector: FlowCollector<T>): Nothing = flow.collect(collector)

--- a/revolver/src/iosMain/kotlin/com/umain/revolver/flow/CStateFlow.kt
+++ b/revolver/src/iosMain/kotlin/com/umain/revolver/flow/CStateFlow.kt
@@ -1,9 +1,11 @@
 package com.umain.revolver.flow
 
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.StateFlow
 
 actual open class CStateFlow<out T : Any> actual constructor(
     private val flow: StateFlow<T>,
-) : CSharedFlow<T>(flow), StateFlow<T> {
+    private val coroutineScope: CoroutineScope,
+    ) : CSharedFlow<T>(flow,coroutineScope), StateFlow<T> {
     override val value: T get() = flow.value
 }


### PR DESCRIPTION
Current implementation of CFlow binds the coroutine scope for IOS to the GlobalScope. This causes the observers on these flows to never close if the ViewModel is disposed, since they are not part of the structured concurrency. This could cause memory leaks as these resources will still be open.

This is fixed by ensuring that the flows could also be bound by the VM scope, and passing the ViewModelScope for the revolver view model usage of CSharedFlow and CStateFlow. This will allow both global and VM scopes to be used for CSharedFlow and CStateFlow if they require a Global scope rather than being bound to the ViewModelScope.

See [GlobalScope](https://kotlinlang.org/api/kotlinx.coroutines/kotlinx-coroutines-core/kotlinx.coroutines/-global-scope/) for explanation why we have to bind the VM scope if we want the observers to be part of the VM scope.