### PR TITLE
Exposes androidx.lifecycle.viewmodel depedency

### DIFF
--- a/revolver/build.gradle.kts
+++ b/revolver/build.gradle.kts
@@ -34,7 +34,7 @@ kotlin {
         }
 
         androidMain.dependencies {
-            implementation(libs.androidx.lifecycle.viewmodel)
+            api(libs.androidx.lifecycle.viewmodel)
         }
     }
 }


### PR DESCRIPTION
### What changed:
Since `BaseViewModel` extends `androidx.lifecycle.ViewModel`, the supertype cannot be resolved in the consumer app, unless it's explicitly declared.

By exposing `androidx.lifecycle.viewmodel`, the consumers of this lib need just to define Revolver as their dependency.